### PR TITLE
Network Error Handling

### DIFF
--- a/Goldspar/Enum/NetworkError.swift
+++ b/Goldspar/Enum/NetworkError.swift
@@ -7,11 +7,28 @@
 
 import Foundation
 
-enum NetworkError: Error {
+enum NetworkError: LocalizedError {
     case invalidURL
     case invalidResponse
     case clientError(Int)
     case serverError(Int)
     case decodingError(Error)
     case unknown
+    
+    var errorDescription: String? {
+        switch self {
+            case .invalidURL:
+                return "Invalid URL"
+            case .invalidResponse:
+                return "Invalid Response"
+            case .clientError(let error):
+                return "Client Error (\(error))"
+            case .serverError(let error):
+                return "Server Error (\(error))"
+            case .decodingError(let error):
+                return "Decoding Error: \(error)"
+            case .unknown:
+                return "Unknown error occured"
+        }
+    }
 }


### PR DESCRIPTION
Convert NetworkError to LocalizedError for localized messenging. Provide a error description.

Changes to be committed:
	modified:   Goldspar/Enum/NetworkError.swift